### PR TITLE
Adicionado métodos para impressão direta 

### DIFF
--- a/src/main/java/br/com/swconsultoria/impressao/service/ImpressaoService.java
+++ b/src/main/java/br/com/swconsultoria/impressao/service/ImpressaoService.java
@@ -1,16 +1,25 @@
 package br.com.swconsultoria.impressao.service;
 
+import br.com.swconsultoria.impressao.exception.DanfeException;
 import br.com.swconsultoria.impressao.model.Impressao;
 import net.sf.jasperreports.engine.*;
 import net.sf.jasperreports.engine.data.JRXmlDataSource;
+import net.sf.jasperreports.engine.export.JRPrintServiceExporter;
+import net.sf.jasperreports.export.SimpleExporterInput;
+import net.sf.jasperreports.export.SimplePrintServiceExporterConfiguration;
 import net.sf.jasperreports.view.JasperViewer;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
+import javax.print.PrintService;
+import javax.print.PrintServiceLookup;
+import javax.print.attribute.HashPrintRequestAttributeSet;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
 import java.io.IOException;
 import java.io.StringReader;
 
@@ -61,7 +70,6 @@ public class ImpressaoService {
     public static void impressaoHtml(Impressao impressao, String destinoHtml) throws JRException, ParserConfigurationException, IOException, SAXException {
         JasperPrint jasperPrint = geraImpressao(impressao);
         JasperExportManager.exportReportToHtmlFile(jasperPrint, destinoHtml);
-
     }
 
     /**
@@ -77,7 +85,101 @@ public class ImpressaoService {
         return new JasperViewer(jasperPrint, true);
     }
 
-    private static JasperPrint geraImpressao(Impressao impressao) throws IOException, SAXException, ParserConfigurationException, JRException {
+    /**
+     * Cria a impressão direta na impressora padrão
+     * @param impressao
+     * @throws JRException
+     * @throws ParserConfigurationException
+     * @throws IOException
+     * @throws SAXException
+     * @throws PrinterException
+     */
+    public static void impressaoDireta(Impressao impressao) throws JRException, ParserConfigurationException, IOException, SAXException, PrinterException {
+        PrintService impressoraPadrao = PrintServiceLookup.lookupDefaultPrintService();
+        impressaoDireta(impressao, impressoraPadrao, null);
+    }
+
+    /**
+     * Cria a impressão direta na impressora padrão passando configuration
+     * @param impressao
+     * @param configuration
+     * @throws JRException
+     * @throws ParserConfigurationException
+     * @throws IOException
+     * @throws SAXException
+     * @throws PrinterException
+     */
+    public static void impressaoDireta(Impressao impressao, SimplePrintServiceExporterConfiguration configuration) throws JRException, ParserConfigurationException, IOException, SAXException, PrinterException {
+        PrintService impressoraPadrao = PrintServiceLookup.lookupDefaultPrintService();
+        impressaoDireta(impressao, impressoraPadrao, configuration);
+    }
+
+    /**
+     * Cria a impressão direta na impressora informada
+     * @param impressao
+     * @param impressora
+     * @throws JRException
+     * @throws ParserConfigurationException
+     * @throws IOException
+     * @throws SAXException
+     * @throws PrinterException
+     */
+    public static void impressaoDireta(Impressao impressao, PrintService impressora) throws JRException, ParserConfigurationException, IOException, SAXException, PrinterException {
+        SimplePrintServiceExporterConfiguration configuration = new SimplePrintServiceExporterConfiguration();
+        configuration.setPrintRequestAttributeSet(new HashPrintRequestAttributeSet());
+        configuration.setDisplayPageDialog(false);
+        configuration.setDisplayPrintDialog(false);
+
+        impressaoDireta(impressao, impressora, configuration);
+    }
+
+    /**
+     * Cria a impressão direta na impressora informada
+     * @param impressao
+     * @param impressora
+     * @throws JRException
+     * @throws ParserConfigurationException
+     * @throws IOException
+     * @throws SAXException
+     * @throws PrinterException
+     */
+    public static void impressaoDireta(Impressao impressao, PrintService impressora, SimplePrintServiceExporterConfiguration configuration) throws JRException, ParserConfigurationException, IOException, SAXException, PrinterException {
+        JasperPrint jasperPrint = geraImpressao(impressao);
+        if (impressora == null) {
+            throw new DanfeException("Impressora não encontrada");
+        }
+
+        if (configuration == null) {
+            configuration = new SimplePrintServiceExporterConfiguration();
+            configuration.setPrintRequestAttributeSet(new HashPrintRequestAttributeSet());
+            configuration.setDisplayPageDialog(false);
+            configuration.setDisplayPrintDialog(false);
+        }
+
+        // Configurações de impressão
+        PrinterJob printerJob = PrinterJob.getPrinterJob();
+        printerJob.setPrintService(impressora);
+
+        // Crie uma impressão Jasper a partir do objeto JasperPrint
+        JRPrintServiceExporter exporter = new JRPrintServiceExporter();
+        exporter.setExporterInput(new SimpleExporterInput(jasperPrint));
+        configuration.setPrintService(impressora);
+        exporter.setConfiguration(configuration);
+
+        // Exportar e imprimir
+        exporter.exportReport();
+    }
+
+    /**
+     * Cria a impressão
+     * @param impressao
+     * @return
+     * @throws IOException
+     * @throws SAXException
+     * @throws ParserConfigurationException
+     * @throws JRException
+     */
+    public static JasperPrint geraImpressao(Impressao impressao) throws IOException, SAXException, ParserConfigurationException, JRException {
         DocumentBuilder docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
         Document document = docBuilder.parse(new InputSource(new StringReader(impressao.getXml())));
         JRDataSource xmlDataSource = new JRXmlDataSource(document, impressao.getPathExpression());

--- a/src/main/java/br/com/swconsultoria/impressao/view/Principal.form
+++ b/src/main/java/br/com/swconsultoria/impressao/view/Principal.form
@@ -5,10 +5,10 @@
     <Property name="defaultCloseOperation" type="int" value="3"/>
     <Property name="title" type="java.lang.String" value="Java-Danfe"/>
     <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-      <Dimension value="[600, 325]"/>
+      <Dimension value="[641, 338]"/>
     </Property>
     <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-      <Dimension value="[600, 325]"/>
+      <Dimension value="[641, 338]"/>
     </Property>
   </Properties>
   <SyntheticProperties>
@@ -25,7 +25,7 @@
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
-    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,25,0,0,2,83"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,82,0,0,2,-127"/>
   </AuxValues>
 
   <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
@@ -50,7 +50,7 @@
               <Group type="102" attributes="0">
                   <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="jLabel2" pref="545" max="32767" attributes="0"/>
+                      <Component id="jLabel2" pref="591" max="32767" attributes="0"/>
                       <Group type="102" alignment="1" attributes="0">
                           <Component id="jbDoc" min="-2" pref="150" max="-2" attributes="0"/>
                           <EmptySpace type="unrelated" max="-2" attributes="0"/>
@@ -68,13 +68,13 @@
                               <Component id="jLabel4" min="-2" max="-2" attributes="0"/>
                               <Group type="102" attributes="0">
                                   <Component id="jcbTipo" min="-2" max="-2" attributes="0"/>
-                                  <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                                  <EmptySpace max="-2" attributes="0"/>
                                   <Component id="jbBuscar" min="-2" max="-2" attributes="0"/>
-                                  <EmptySpace type="unrelated" max="-2" attributes="0"/>
-                                  <Component id="jcbSalvarPDF" min="-2" max="-2" attributes="0"/>
                               </Group>
+                              <Component id="jcbSalvarPDF" alignment="0" min="-2" pref="348" max="-2" attributes="0"/>
+                              <Component id="jcbEnviarImpressaoDireta" alignment="0" min="-2" pref="348" max="-2" attributes="0"/>
                           </Group>
-                          <EmptySpace min="0" pref="36" max="32767" attributes="0"/>
+                          <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
                       </Group>
                   </Group>
               </Group>
@@ -95,9 +95,12 @@
                   <Group type="103" groupAlignment="3" attributes="0">
                       <Component id="jcbTipo" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="jbBuscar" alignment="3" min="-2" max="-2" attributes="0"/>
-                      <Component id="jcbSalvarPDF" alignment="3" min="-2" max="-2" attributes="0"/>
                   </Group>
-                  <EmptySpace type="separate" pref="37" max="32767" attributes="0"/>
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Component id="jcbSalvarPDF" min="-2" pref="25" max="-2" attributes="0"/>
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Component id="jcbEnviarImpressaoDireta" min="-2" pref="25" max="-2" attributes="0"/>
+                  <EmptySpace pref="32" max="32767" attributes="0"/>
                   <Group type="103" groupAlignment="3" attributes="0">
                       <Component id="jbTema" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="jbDoc" alignment="3" min="-2" max="-2" attributes="0"/>
@@ -230,7 +233,15 @@
         </Component>
         <Component class="javax.swing.JCheckBox" name="jcbSalvarPDF">
           <Properties>
-            <Property name="text" type="java.lang.String" value="Salvar PDF"/>
+            <Property name="text" type="java.lang.String" value="Marque aqui para salvar um PDF do XML ap&#xf3;s seleciona-lo."/>
+            <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[85, 35]"/>
+            </Property>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JCheckBox" name="jcbEnviarImpressaoDireta">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Enviar impress&#xe3;o direta ap&#xf3;s selecionar xml."/>
             <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
               <Dimension value="[85, 35]"/>
             </Property>

--- a/src/main/java/br/com/swconsultoria/impressao/view/Principal.java
+++ b/src/main/java/br/com/swconsultoria/impressao/view/Principal.java
@@ -83,11 +83,12 @@ public class Principal extends javax.swing.JFrame {
         jLabel4 = new javax.swing.JLabel();
         jbBuscar = new javax.swing.JButton();
         jcbSalvarPDF = new javax.swing.JCheckBox();
+        jcbEnviarImpressaoDireta = new javax.swing.JCheckBox();
 
         setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
         setTitle("Java-Danfe");
-        setMinimumSize(new java.awt.Dimension(600, 325));
-        setPreferredSize(new java.awt.Dimension(600, 325));
+        setMinimumSize(new java.awt.Dimension(641, 338));
+        setPreferredSize(new java.awt.Dimension(641, 338));
 
         jPanel1.setBorder(javax.swing.BorderFactory.createEmptyBorder(18, 22, 18, 22));
 
@@ -106,7 +107,7 @@ public class Principal extends javax.swing.JFrame {
             }
         });
 
-        jLabel2.setText("Esta biblioteca tem como propósito facilitar a impressão dos documentos NF-e, NFC-e, CT-e e MDFe.");
+        jLabel2.setText("Esta biblioteca tem como propósito facilitar a impressão dos documentos NF-e, NFC-e e CT-e.");
 
         jbTema.setIcon(new javax.swing.ImageIcon(getClass().getResource("/icons/Paint Roller.png"))); // NOI18N
         jbTema.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
@@ -133,8 +134,7 @@ public class Principal extends javax.swing.JFrame {
             }
         });
 
-        jcbTipo.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "NFe - Nota Fiscal Eletrônica", "NFCe - Nota Fiscal Consumidor Eletrônica",
-                "CTe - Conhecimento de Transporte Eletrônico", "MDFe - Manifesto Eletronico de Documentos Fiscais" }));
+        jcbTipo.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "NFe - Nota Fiscal Eletrônica", "NFCe - Nota Fiscal Consumidor Eletrônica", "CTe - Conhecimento de Transporte Eletrônico" }));
         jcbTipo.setFocusable(false);
         jcbTipo.setMinimumSize(new java.awt.Dimension(300, 35));
         jcbTipo.setPreferredSize(new java.awt.Dimension(300, 35));
@@ -153,8 +153,11 @@ public class Principal extends javax.swing.JFrame {
             }
         });
 
-        jcbSalvarPDF.setText("Salvar PDF");
+        jcbSalvarPDF.setText("Marque aqui para salvar um PDF do XML após seleciona-lo.");
         jcbSalvarPDF.setPreferredSize(new java.awt.Dimension(85, 35));
+
+        jcbEnviarImpressaoDireta.setText("Enviar impressão direta após selecionar xml.");
+        jcbEnviarImpressaoDireta.setPreferredSize(new java.awt.Dimension(85, 35));
 
         javax.swing.GroupLayout jPanel1Layout = new javax.swing.GroupLayout(jPanel1);
         jPanel1.setLayout(jPanel1Layout);
@@ -163,7 +166,7 @@ public class Principal extends javax.swing.JFrame {
             .addGroup(jPanel1Layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(jLabel2, javax.swing.GroupLayout.DEFAULT_SIZE, 545, Short.MAX_VALUE)
+                    .addComponent(jLabel2, javax.swing.GroupLayout.DEFAULT_SIZE, 591, Short.MAX_VALUE)
                     .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel1Layout.createSequentialGroup()
                         .addComponent(jbDoc, javax.swing.GroupLayout.PREFERRED_SIZE, 150, javax.swing.GroupLayout.PREFERRED_SIZE)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
@@ -179,11 +182,11 @@ public class Principal extends javax.swing.JFrame {
                             .addComponent(jLabel4)
                             .addGroup(jPanel1Layout.createSequentialGroup()
                                 .addComponent(jcbTipo, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                                .addComponent(jbBuscar, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                                .addComponent(jcbSalvarPDF, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))
-                        .addGap(0, 36, Short.MAX_VALUE))))
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(jbBuscar, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                            .addComponent(jcbSalvarPDF, javax.swing.GroupLayout.PREFERRED_SIZE, 348, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(jcbEnviarImpressaoDireta, javax.swing.GroupLayout.PREFERRED_SIZE, 348, javax.swing.GroupLayout.PREFERRED_SIZE))
+                        .addGap(0, 0, Short.MAX_VALUE))))
         );
         jPanel1Layout.setVerticalGroup(
             jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -199,9 +202,12 @@ public class Principal extends javax.swing.JFrame {
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jcbTipo, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jbBuscar, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jcbSalvarPDF, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addGap(18, 37, Short.MAX_VALUE)
+                    .addComponent(jbBuscar, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(jcbSalvarPDF, javax.swing.GroupLayout.PREFERRED_SIZE, 25, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(jcbEnviarImpressaoDireta, javax.swing.GroupLayout.PREFERRED_SIZE, 25, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 32, Short.MAX_VALUE)
                 .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jbTema, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(jbDoc, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
@@ -286,6 +292,10 @@ public class Principal extends javax.swing.JFrame {
                     impressao = ImpressaoUtil.impressaoPadraoNFe(xml);
                     break;
                 }
+            }
+            
+            if (jcbEnviarImpressaoDireta.isSelected()) {
+                ImpressaoService.impressaoDireta(impressao);
             }
 
             if (jcbSalvarPDF.isSelected()) {
@@ -401,6 +411,7 @@ public class Principal extends javax.swing.JFrame {
     private javax.swing.JButton jbDoc;
     private javax.swing.JButton jbGithub;
     private javax.swing.JButton jbTema;
+    private javax.swing.JCheckBox jcbEnviarImpressaoDireta;
     private javax.swing.JCheckBox jcbSalvarPDF;
     private javax.swing.JComboBox<String> jcbTipo;
     // End of variables declaration//GEN-END:variables


### PR DESCRIPTION
### Implementado
Métodos para impressão direta
```java
// Usando impressora e configuração padrão
ImpressaoService.impressaoDireta(Impressao impressao);

// Usando impressora padrão
ImpressaoService.impressaoDireta(Impressao impressao, SimplePrintServiceExporterConfiguration configuration);

// Usando configuração padrão
ImpressaoService.impressaoDireta(Impressao impressao, PrintService impressora);

// Passando todos parâmetros de configuração
ImpressaoService.impressaoDireta(Impressao impressao, PrintService impressora, SimplePrintServiceExporterConfiguration configuration);
```

### Alterações
Alterado `geraImpressao` para `public`, assim é possivel manipular diretamente o `JasperPrint`
```java
JasperPrint jasperPrint = ImpressaoService.geraImpressao(Impressao impressao);
```