### PR TITLE
Melhora formatação do telefone do emitente na DANFE

### DIFF
--- a/src/main/resources/jasper/nfe/danfe.jrxml
+++ b/src/main/resources/jasper/nfe/danfe.jrxml
@@ -1357,9 +1357,19 @@ $F{Chave}.substring(36,40) + " " + $F{Chave}.substring(40,44) + " "]]></textFiel
 					<textElement textAlignment="Center">
 						<font size="7" isBold="false"/>
 					</textElement>
-					<textFieldExpression><![CDATA[$F{Emi_Telefone}.length() == 8 ? "FONE: " + $F{Emi_Telefone}.substring(0,4) +
-"-" + $F{Emi_Telefone}.substring(4,8) : "FONE: (" + $F{Emi_Telefone}.substring(0,2) + ") " +
-$F{Emi_Telefone}.substring(2,6) + "-" + $F{Emi_Telefone}.substring(6,10)]]></textFieldExpression>
+					<textFieldExpression><![CDATA[($F{Emi_Telefone} == null || $F{Emi_Telefone}.replaceAll("[^0-9]", "").isEmpty()) ? 
+    "" : 
+(
+    ($F{Emi_Telefone}.replaceAll("[^0-9]", "").length() == 8) ?
+        "FONE: " + $F{Emi_Telefone}.replaceAll("[^0-9]", "").substring(0, 4) + "-" + $F{Emi_Telefone}.replaceAll("[^0-9]", "").substring(4, 8) :
+    ($F{Emi_Telefone}.replaceAll("[^0-9]", "").length() == 9) ?
+        "FONE: " + $F{Emi_Telefone}.replaceAll("[^0-9]", "").substring(0, 1) + " " + $F{Emi_Telefone}.replaceAll("[^0-9]", "").substring(1, 5) + "-" + $F{Emi_Telefone}.replaceAll("[^0-9]", "").substring(5, 9) :
+    ($F{Emi_Telefone}.replaceAll("[^0-9]", "").length() == 10) ?
+        "FONE: (" + $F{Emi_Telefone}.replaceAll("[^0-9]", "").substring(0, 2) + ") " + $F{Emi_Telefone}.replaceAll("[^0-9]", "").substring(2, 6) + "-" + $F{Emi_Telefone}.replaceAll("[^0-9]", "").substring(6, 10) :
+    ($F{Emi_Telefone}.replaceAll("[^0-9]", "").length() == 11) ?
+        "FONE: (" + $F{Emi_Telefone}.replaceAll("[^0-9]", "").substring(0, 2) + ") " + $F{Emi_Telefone}.replaceAll("[^0-9]", "").substring(2, 3) + " " + $F{Emi_Telefone}.replaceAll("[^0-9]", "").substring(3, 7) + "-" + $F{Emi_Telefone}.replaceAll("[^0-9]", "").substring(7, 11) :
+        "FONE: " + $F{Emi_Telefone}.replaceAll("[^0-9]", "")
+)]]></textFieldExpression>
 				</textField>
 				<textField textAdjust="StretchHeight" pattern="dd/MM/yyyy HH:mm:ss">
 					<reportElement style="dados" positionType="Float" x="454" y="103" width="109" height="16" isPrintInFirstWholeBand="true" uuid="94e62645-5088-47f1-ba93-ae6047b045f3"/>


### PR DESCRIPTION
### 🛠️ Descrição do PR

**Melhoria na formatação do número de telefone do emitente na DANFE**

Este PR implementa uma melhoria na expressão utilizada para exibir o telefone do emitente na DANFE, permitindo a utilização de numeros de celular (9 ou 11 dígitos) e garantindo maior robustez e compatibilidade com diferentes formatos de entrada. A formatação agora considera corretamente os seguintes casos:

### ✅ Formatos suportados:
- **8 dígitos**: `9999-9999`
- **9 dígitos**: `9 9999-9999`
- **10 dígitos**: `(99) 9999-9999`
- **11 dígitos**: `(99) 9 9999-9999`

Também foi adicionada a **limpeza automática do número**, removendo quaisquer caracteres não numéricos (ex: parênteses, espaços, traços, etc), e tratamento de valores `null` ou vazios, evitando quebras no relatório.

### 💡 Exemplo de entrada e saída:

| Entrada             | Saída                     |
|---------------------|---------------------------|
| `43912345678`       | `FONE: (43) 9 1234-5678`   |
| `(43)91234-5678`    | `FONE: (43) 9 1234-5678`   |
| `1234-5678`         | `FONE: 1234-5678`          |
| `912345678`         | `FONE: 9 1234-5678`        |
| `null` ou vazio     | `""` (string vazia)        |

### 🧩 Onde foi aplicada a alteração

Campo `$F{Emi_Telefone}` dentro do relatório Jasper (DANFE), substituindo a lógica anterior por uma nova expressão condicional mais abrangente.
